### PR TITLE
Godot 4 to Godot 3 Camera test

### DIFF
--- a/Ensured_Energy/scenes/World.tscn
+++ b/Ensured_Energy/scenes/World.tscn
@@ -10,6 +10,5 @@ texture = ExtResource( 2 )
 
 [node name="Camera2D" type="Camera2D" parent="."]
 current = true
-zoom = Vector2( 2, 2 )
-smoothing_enabled = true
+zoom = Vector2( 4, 4 )
 script = ExtResource( 1 )

--- a/Ensured_Energy/src/cs/MouseButton.cs
+++ b/Ensured_Energy/src/cs/MouseButton.cs
@@ -1,0 +1,16 @@
+using Godot;
+
+// Godot 4 MouseButton enum workaround
+public class MouseButton : Node
+{
+    public static readonly int None = 0;
+    public static readonly int Left = 1;
+    public static readonly int Right = 2;
+    public static readonly int Middle = 3;
+    public static readonly int WheelUp = 4;
+    public static readonly int WheelDown = 5;
+    public static readonly int WheelLeft = 6;
+    public static readonly int WheelRight = 7;
+    public static readonly int Xbutton1 = 8;
+    public static readonly int Xbutton2 = 9;
+}

--- a/Ensured_Energy/src/cs/MouseButtonMask.cs
+++ b/Ensured_Energy/src/cs/MouseButtonMask.cs
@@ -1,0 +1,11 @@
+using Godot;
+
+// Godot 4 MouseButtonMask enum workaround
+public class MouseButtonMask : Node
+{
+    public static readonly int Left = 1;
+    public static readonly int Right = 2;
+    public static readonly int Middle = 4;
+    public static readonly int Xbutton1 = 128;
+    public static readonly int Xbutton2 = 256;
+}


### PR DESCRIPTION
The camera zoom and pan have been adapted to work with Godot 3.
The pan is not yet restricted to the map limits, as it is in the Godot 4 version.